### PR TITLE
Compile on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 add_subdirectory(benchmark)
 find_package(folly CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(gflags REQUIRED)
+
+# lockfree introduced in Boost 1.53.0
+# and requires the following components
+find_package(Boost 1.53.0 COMPONENTS thread program_options context filesystem regex system)
 
 add_executable(RingBufferBenchmark
     DummyContainer.hpp
@@ -27,7 +32,7 @@ add_executable(RingBufferBenchmark
     rigtorpSPSCQueue.h
     moodycamel/atomicops.h
     moodycamel/readwriterqueue.h
-    
+
     LamportQueue2.hpp
     LamportQueue3.hpp
     LamportQueue4.hpp
@@ -80,4 +85,3 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 else()
     message(ERROR "Unknown compiler")
 endif()
-

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ RingBufferBenchmark.sln
 cd ..
 ```
 
-### Others
+### Linux with Clang
 
-TBD
+```
+git submodule update --init
+mkdir build
+cd build
+cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release ..
+./RingBufferBenchmark
+```

--- a/README.md
+++ b/README.md
@@ -30,9 +30,22 @@ cd ..
 ### Linux with Clang
 
 ```
+git clone https://github.com/Deaod/RingBufferBenchmark
+cd RingBufferBenchmark
 git submodule update --init
 mkdir build
 cd build
+
+# Build
 cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc)
+
+# Run
 ./RingBufferBenchmark
 ```
+
+Note: Clang will output about 600 warnings that some values are uninitialized
+
+### Linux with GCC
+
+The codebase currently does not compile with GCC 8 and GCC 9

--- a/aligned_alloc.hpp
+++ b/aligned_alloc.hpp
@@ -13,14 +13,12 @@ inline void aligned_free(void* ptr) {
     _aligned_free(ptr);
 }
 
-#elif __STDC_VERSION__ >= 201112L
+#else
 
 inline void aligned_free(void* ptr) {
     free(ptr);
 }
 
-#else
-#error "No known way to implement aligned_alloc, please add new branch."
 #endif
 
 // For use with std::unique_ptr as deleter
@@ -29,4 +27,3 @@ struct aligned_free_deleter {
         aligned_free(ptr);
     }
 };
-

--- a/spsc_ring_buffer_heap.hpp
+++ b/spsc_ring_buffer_heap.hpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <array>
 #include <limits>
+#include <memory>
 #include "aligned_alloc.hpp"
 #include "compile_time_utilities.hpp"
 #include "scope_guard.hpp"


### PR DESCRIPTION
This updates cmake and the codebase to compile on Linux with Clang (tested with clang v9).

I didn't check the impact on Windows/MSVC.

Clang raises about 600+ warnings that some variables are not initialized so this might require -Wno-uninitialized if those are intended.

Compilation with GCC 8 or GCC 9 fails due to casting unique_ptr to void pointer

```
In file included from /home/beta/Programming/Concurrency/RingBufferBenchmark/RingBufferBenchmark.cpp:8:
/home/beta/Programming/Concurrency/RingBufferBenchmark/spsc_ring_buffer_heap.hpp: In copy constructor ‘spsc_ring_buffer_heap<_buffer_size_log2, _content_align_log2, _difference_type, _align_log2>::spsc_ring_buffer_heap(const spsc_ring_buffer_heap<_buffer_size_log2, _content_align_log2, _difference_type, _align_log2>&)’:
/home/beta/Programming/Concurrency/RingBufferBenchmark/spsc_ring_buffer_heap.hpp:39:16: error: cannot convert ‘std::unique_ptr<std::byte, aligned_free_deleter>’ to ‘void*’
         memcpy(_buffer, other._buffer, size);
                ^~~~~~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/c++/cstring:42,
                 from /home/beta/Programming/Concurrency/RingBufferBenchmark/spsc_queue.hpp:6,
                 from /home/beta/Programming/Concurrency/RingBufferBenchmark/RingBufferBenchmark.cpp:3:
/usr/include/string.h:42:39: note:   initializing argument 1 of ‘void* memcpy(void*, const void*, size_t)’
 extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
                      ~~~~~~~~~~~~~~~~~^~~~~~
In file included from /home/beta/Programming/Concurrency/RingBufferBenchmark/RingBufferBenchmark.cpp:8:
/home/beta/Programming/Concurrency/RingBufferBenchmark/spsc_ring_buffer_heap.hpp: In member function ‘spsc_ring_buffer_heap<_buffer_size_log2, _content_align_log2, _difference_type, _align_log2>& spsc_ring_buffer_heap<_buffer_size_log2, _content_align_log2, _difference_type, _align_log2>::operator=(const spsc_ring_buffer_heap<_buffer_size_log2, _content_align_log2, _difference_type, _align_log2>&)’:
/home/beta/Programming/Concurrency/RingBufferBenchmark/spsc_ring_buffer_heap.hpp:43:16: error: cannot convert ‘std::unique_ptr<std::byte, aligned_free_deleter>’ to ‘void*’
         memcpy(_buffer, other._buffer, size);
                ^~~~~~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/c++/cstring:42,
                 from /home/beta/Programming/Concurrency/RingBufferBenchmark/spsc_queue.hpp:6,
                 from /home/beta/Programming/Concurrency/RingBufferBenchmark/RingBufferBenchmark.cpp:3:
/usr/include/string.h:42:39: note:   initializing argument 1 of ‘void* memcpy(void*, const void*, size_t)’
 extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
                      ~~~~~~~~~~~~~~~~~^~~~~~
```